### PR TITLE
Removes unused extern C method.

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,15 +78,21 @@ maliput_drake/src/systems/analysis/region_of_attraction.cc
 maliput_drake/src/systems/analysis/simulator_print_stats.cc
 ```
 
-8. Update the CMakeLists.txt under `maliput_drake/src/` for the library targets.
+8. Removes the following method from `maliput_drake/src/common/drake_assert_and_throw.cc`.
+   ```cpp
+   extern "C" void drake_set_assertion_failure_to_throw_excepts()
+   ```
+   To avoid having duplicated references in systems that both `maliput_drake` and `drake` are installed.
+
+9. Update the CMakeLists.txt under `maliput_drake/src/` for the library targets.
    Make sure all source files are properly listed.
 
-9. Commit all the changes.
+10. Commit all the changes.
 
-10. Run the steps listed in the `Namespacing` section. Make a new commit per
+11. Run the steps listed in the `Namespacing` section. Make a new commit per
     change.
 
-11. Test the workspace before making a PR.
+12. Test the workspace before making a PR.
 
 ### Namespacing
 

--- a/maliput_drake/src/common/drake_assert_and_throw.cc
+++ b/maliput_drake/src/common/drake_assert_and_throw.cc
@@ -69,19 +69,3 @@ void AssertionFailed(const char* condition, const char* func, const char* file,
 
 }  // namespace internal
 }  // namespace maliput::drake
-
-// Configures the DRAKE_ASSERT and DRAKE_DEMAND assertion failure handling
-// behavior.
-//
-// By default, assertion failures will result in an ::abort().  If this method
-// has ever been called, failures will result in a thrown exception instead.
-//
-// Assertion configuration has process-wide scope.  Changes here will affect
-// all assertions within the current process.
-//
-// This method is intended ONLY for use by pydrake bindings, and thus is not
-// declared in any header file, to discourage anyone from using it.
-extern "C" void drake_set_assertion_failure_to_throw_exception() {
-  maliput::drake::internal::AssertionConfig::singleton().
-      assertion_failures_are_exceptions = true;
-}


### PR DESCRIPTION
The method 
```cpp
extern "C" void drake_set_assertion_failure_to_throw_exception()
```
is expected to be used only by pydrake bindings which weren't ported from `drake` to `maliput_drake`.

Given that this method doesn't suffer any kind of name mangling by the compiler because of the `extern C` declaration, it could cause duplicated symbol errors downstream when both `drake` and `maliput_drake` are being used.

[From slack thread](https://tri-internal.slack.com/archives/C028K32S4FP/p1634314528114800)