### PR TITLE
Revert "Remove autodiff and symbolic instantiations"

### DIFF
--- a/README.md
+++ b/README.md
@@ -132,16 +132,12 @@ maliput_drake/src/systems/analysis/simulator_print_stats.cc
     ```
     And replace all the occurrences.
 
-11. Edit `maliput_drake/include/maliput/drake/common/default_scalars.h` to remove all `AutoDiff` and
-    `Symbolic` template instantiations. That would reduce the compile time and library size given
-    that the entire maliput API supports `doubles` only.
+11. Commit all the changes.
 
-12. Commit all the changes.
-
-13. Run the steps listed in the `Namespacing` section. Make a new commit per
+12. Run the steps listed in the `Namespacing` section. Make a new commit per
     change.
 
-14. Test the workspace before making a PR.
+13. Test the workspace before making a PR.
 
 ### Namespacing
 

--- a/maliput_drake/include/maliput/drake/common/default_scalars.h
+++ b/maliput_drake/include/maliput/drake/common/default_scalars.h
@@ -3,11 +3,6 @@
 #include "maliput/drake/common/autodiff.h"
 #include "maliput/drake/common/symbolic.h"
 
-// Note: this file has been changed to only declare template instantiations
-// for double. Maliput backends do not have support for autodiff or symbolic
-// expressions so there is no point in adding extra compile time for something
-// that will not be used at all.
-
 // N.B. `CommonScalarPack` and `NonSymbolicScalarPack` in `systems_pybind.h`
 // should be kept in sync with this file.
 
@@ -82,27 +77,33 @@
 /// This should only be used in .cc files, never in .h files.
 #define DRAKE_DEFINE_CLASS_TEMPLATE_INSTANTIATIONS_ON_DEFAULT_SCALARS( \
     SomeType) \
-template SomeType<double>;
+template SomeType<double>; \
+template SomeType<::maliput::drake::AutoDiffXd>; \
+template SomeType<::maliput::drake::symbolic::Expression>;
 
 /// Defines template instantiations for Drake's default nonsymbolic scalars.
 /// This should only be used in .cc files, never in .h files.
 #define \
   DRAKE_DEFINE_CLASS_TEMPLATE_INSTANTIATIONS_ON_DEFAULT_NONSYMBOLIC_SCALARS( \
       SomeType) \
-template SomeType<double>;
+template SomeType<double>; \
+template SomeType<::maliput::drake::AutoDiffXd>;
 
 /// Declares that template instantiations exist for Drake's default scalars.
 /// This should only be used in .h files, never in .cc files.
 #define DRAKE_DECLARE_CLASS_TEMPLATE_INSTANTIATIONS_ON_DEFAULT_SCALARS(  \
     SomeType) \
-extern template SomeType<double>;
+extern template SomeType<double>; \
+extern template SomeType<::maliput::drake::AutoDiffXd>; \
+extern template SomeType<::maliput::drake::symbolic::Expression>;
 
 /// Declares that template instantiations exist for Drake's default nonsymbolic
 /// scalars.  This should only be used in .h files, never in .cc files.
 #define \
   DRAKE_DECLARE_CLASS_TEMPLATE_INSTANTIATIONS_ON_DEFAULT_NONSYMBOLIC_SCALARS( \
       SomeType) \
-extern template SomeType<double>;
+extern template SomeType<double>; \
+extern template SomeType<::maliput::drake::AutoDiffXd>;
 
 /// @}
 
@@ -201,7 +202,9 @@ constexpr auto Make_Function_Pointers_Pack1() { \
 } \
 static constexpr auto Function_Femplates __attribute__((used)) = \
     Make_Function_Pointers_Pack1< \
-        double>();
+        double, \
+        ::maliput::drake::AutoDiffXd, \
+        ::maliput::drake::symbolic::Expression>();
 
 /// Defines template instantiations for Drake's default nonsymbolic scalars.
 /// This should only be used in .cc files, never in .h files.
@@ -222,6 +225,7 @@ constexpr auto Make_Function_Pointers_Nonsym_Pack1() { \
 } \
 static constexpr auto Function_Templates_Nonsym __attribute__((used)) = \
     Make_Function_Pointers_Nonsym_Pack1< \
-        double>();
+        double, \
+        ::maliput::drake::AutoDiffXd>();
 
 /// @}


### PR DESCRIPTION
Reverts ToyotaResearchInstitute/maliput_drake#11

See https://github.com/ToyotaResearchInstitute/maliput_infrastructure/actions/runs/1407204472 . It failed because of missing template instantiation of maliput_drake. It affects maliput_malidrive and maliput_multilane.